### PR TITLE
docs: Add empty chapter skeleton for development and computing environments

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -11,7 +11,7 @@ parts:
     - file: fundamentals/conventional-commits
     - file: fundamentals/test-debug
     - file: fundamentals/share-deploy
-    - file: fundamentals/computing-development-environments
+    - file: fundamentals/computing-development-environments/index
       sections:
         - file: fundamentals/computing-development-environments/conda-mamba
         - file: fundamentals/computing-development-environments/docker

--- a/_toc.yml
+++ b/_toc.yml
@@ -11,3 +11,9 @@ parts:
     - file: fundamentals/conventional-commits
     - file: fundamentals/test-debug
     - file: fundamentals/share-deploy
+    - file: fundamentals/computing-development-environment
+      sections:
+        - file: fundamentals/computing-development-environment/conda-mamba
+        - file: fundamentals/computing-development-environment/docker
+        - file: fundamentals/computing-development-environment/pixi
+        - file: fundamentals/computing-development-environment/notebooks-interactive-environments

--- a/_toc.yml
+++ b/_toc.yml
@@ -11,9 +11,9 @@ parts:
     - file: fundamentals/conventional-commits
     - file: fundamentals/test-debug
     - file: fundamentals/share-deploy
-    - file: fundamentals/computing-development-environment
+    - file: fundamentals/computing-development-environments
       sections:
-        - file: fundamentals/computing-development-environment/conda-mamba
-        - file: fundamentals/computing-development-environment/docker
-        - file: fundamentals/computing-development-environment/pixi
-        - file: fundamentals/computing-development-environment/notebooks-interactive-environments
+        - file: fundamentals/computing-development-environments/conda-mamba
+        - file: fundamentals/computing-development-environments/docker
+        - file: fundamentals/computing-development-environments/pixi
+        - file: fundamentals/computing-development-environments/notebooks-interactive-environments

--- a/fundamentals/computing-development-environments/conda-mamba.md
+++ b/fundamentals/computing-development-environments/conda-mamba.md
@@ -1,0 +1,3 @@
+# Conda/Mamba
+
+Coming soon! ([#36](https://github.com/uw-ssec/rse-guidelines/issues/36))

--- a/fundamentals/computing-development-environments/docker.md
+++ b/fundamentals/computing-development-environments/docker.md
@@ -1,0 +1,3 @@
+# Docker
+
+Coming soon ([#34](https://github.com/uw-ssec/rse-guidelines/issues/34))

--- a/fundamentals/computing-development-environments/index.md
+++ b/fundamentals/computing-development-environments/index.md
@@ -1,3 +1,8 @@
 # Computing and Development Environments
 
 Coming soon
+
+Table of contents
+
+```{tableofcontents}
+```

--- a/fundamentals/computing-development-environments/index.md
+++ b/fundamentals/computing-development-environments/index.md
@@ -1,0 +1,3 @@
+# Computing and Development Environments
+
+Coming soon

--- a/fundamentals/computing-development-environments/notebooks-interactive-environments.md
+++ b/fundamentals/computing-development-environments/notebooks-interactive-environments.md
@@ -1,0 +1,3 @@
+# Notebooks and Interactive Environments
+
+Coming Soon! ([#9](https://github.com/uw-ssec/rse-guidelines/issues/9))

--- a/fundamentals/computing-development-environments/pixi.md
+++ b/fundamentals/computing-development-environments/pixi.md
@@ -1,0 +1,3 @@
+# Pixi
+
+Coming soon! ([#35](https://github.com/uw-ssec/rse-guidelines/issues/35))


### PR DESCRIPTION
Adds a chapter skeleton under the `fundamentals` part for the development and computing environments, following what's in here: https://github.com/uw-ssec/rse-guidelines/issues/33

Allows for contributors to the sections to just have a place to write without thinking about structure