### PR TITLE
docs: Add link to pixi documentation

### DIFF
--- a/fundamentals/computing-development-environments/pixi.md
+++ b/fundamentals/computing-development-environments/pixi.md
@@ -1,3 +1,5 @@
 # Pixi
 
 Coming soon! ([#35](https://github.com/uw-ssec/rse-guidelines/issues/35))
+
+https://pixi.sh/latest/


### PR DESCRIPTION
Just adding a link for demo purposes :)