### PR TITLE
docs: Add Advanced part, code deployment section, and skeletons for deployment sections

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -17,3 +17,10 @@ parts:
         - file: fundamentals/computing-development-environments/docker
         - file: fundamentals/computing-development-environments/pixi
         - file: fundamentals/computing-development-environments/notebooks-interactive-environments
+  - caption: Advanced
+    chapters:
+    - file: advanced/deployment-strategies-tools/index
+      sections:
+        - file: advanced/deployment-strategies-tools/cloud-infrastructure-and-services
+        - file: advanced/deployment-strategies-tools/kubernetes
+        - file: advanced/deployment-strategies-tools/docker-advanced

--- a/advanced/deployment-strategies-tools/cloud-infrastructure-and-services.md
+++ b/advanced/deployment-strategies-tools/cloud-infrastructure-and-services.md
@@ -1,0 +1,3 @@
+# Cloud Infrastructure and Services
+
+Coming soon! ([#62](https://github.com/uw-ssec/rse-guidelines/issues/62))

--- a/advanced/deployment-strategies-tools/docker-advanced.md
+++ b/advanced/deployment-strategies-tools/docker-advanced.md
@@ -1,0 +1,3 @@
+# Docker Advanced
+
+Coming soon! ([#60](https://github.com/uw-ssec/rse-guidelines/issues/60))

--- a/advanced/deployment-strategies-tools/index.md
+++ b/advanced/deployment-strategies-tools/index.md
@@ -1,0 +1,8 @@
+# Code Deployment Strategies and Tools
+
+Coming soon
+
+Table of contents
+
+```{tableofcontents}
+```

--- a/advanced/deployment-strategies-tools/kubernetes.md
+++ b/advanced/deployment-strategies-tools/kubernetes.md
@@ -1,0 +1,3 @@
+# Kubernetes
+
+Coming soon! ([#61](https://github.com/uw-ssec/rse-guidelines/issues/61))


### PR DESCRIPTION
similar to https://github.com/uw-ssec/rse-guidelines/pull/64 

Follows structure laid out in #58 

Allows for contributors to have a place to write without thinking about structure