### PR TITLE
chore: Add madeline to codeowner for guideline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lsetiawan @uwcdc @nikiburggraf
+* @lsetiawan @uwcdc @nikiburggraf @madelinegordon


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change adds a new team member, `@madelinegordon`, to the list of code owners.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L1-R1): Added `@madelinegordon` to the list of code owners.