### PR TITLE
fix: update conda package search link to conda-forge (#71)

### DIFF
--- a/docs/fundamentals/computing-development-environments/conda-mamba.md
+++ b/docs/fundamentals/computing-development-environments/conda-mamba.md
@@ -136,7 +136,7 @@ What is a conda package?
 - Cross platform
 - Made from **recipes**
 
-You can search for conda packages at <https://anaconda.org/> or the terminal shown below.
+You can search for conda packages using the terminal (shown below) or at <https://conda-forge.org/packages/>.
 
 ```console
 # Look at the packages you have installed


### PR DESCRIPTION
## Summary
Fixes #71.

Despite the MkDocs migration (673afe6) largely addressing this (`conda-mamba.md` already recommends Miniforge over Anaconda), there was still a remaining reference on line 139 to direct users to `anaconda.org` for package search, so this PR updates that to `conda-forge.org/packages/`.