### PR TITLE
docs: rewrite pixi page as a verified fundamentals guide

### DIFF
--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -662,12 +662,23 @@ pixi global install ruff
 ```
 
 ```text
-Global environments as specified in '~/.pixi/manifests/pixi-global.toml'
-└── ruff: 0.15.22
+└── ruff: 0.16.0 (installed)
     └─ exposes: ruff
 ```
 
-`pixi global list` shows what you have installed globally and which commands each one exposes on your `PATH` — here, the `ruff` environment exposes a single `ruff` command. A tool with several entry points can expose more than one; `--expose` lets you control exactly which binaries from the installed package become available on your `PATH`, and under what name, rather than accepting all of them.
+To see what you have installed globally and which commands each one exposes on your `PATH`, run `pixi global list`:
+
+```bash
+pixi global list
+```
+
+```text
+Global environments as specified in '~/.pixi/manifests/pixi-global.toml'
+└── ruff: 0.16.0
+    └─ exposes: ruff
+```
+
+Here, the `ruff` environment exposes a single `ruff` command. A tool with several entry points can expose more than one; `--expose` lets you control exactly which binaries from the installed package become available on your `PATH`, and under what name, rather than accepting all of them.
 
 Keep the distinction in mind: `pixi add` changes a project's manifest and lock file, checked into git, reproducible on any machine that clones the project. `pixi global install` changes state on *your* machine, outside any project — nothing about it is recorded in `my-analysis`, and a collaborator cloning your repository gets no trace of it. Reach for it for tools you personally use across projects, not for anything a project needs to run.
 

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -82,7 +82,7 @@ On Windows you can download the [installer](https://github.com/prefix-dev/pixi/r
 powershell -ExecutionPolicy ByPass -c "irm -useb https://pixi.sh/install.ps1 | iex"
 ```
 
-For other installation methods go the the [pixi installation docs](https://pixi.sh/latest/installation/).
+For other installation methods go to the [pixi installation docs](https://pixi.sh/latest/installation/).
 
 ### Verification
 

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -191,3 +191,176 @@ Two new things appeared: `pixi.lock` and `.pixi/`. Their sizes on disk tell you 
 - **`.pixi/` is the environment directory: a disposable build product.** It's the actual environment — interpreter and packages unpacked on disk — built from `pixi.lock`. It's gitignored, and pixi can rebuild it from the lock file at any time.
 
 Commit `pixi.toml` and `pixi.lock`. Never commit `.pixi/`.
+
+## Running code
+
+There's no environment to activate. Run a single command inside the project's environment with `pixi run`:
+
+```bash
+pixi run python -V
+pixi run python -c "import numpy; print(numpy.__version__)"
+```
+
+Each invocation resolves the environment, runs the one command you gave it, and exits — nothing lingers in your shell. `pixi run` works from anywhere in the project tree, not just the directory holding `pixi.toml`, so you don't need to `cd` to the project root first.
+
+For a longer interactive session, drop into a shell with the environment already set up instead:
+
+```bash
+pixi shell
+```
+
+```bash
+exit
+```
+
+`exit` (or `Ctrl-D`) leaves the shell and returns you to whatever environment, or lack of one, you had before. Either way — `pixi run` for one-off commands, `pixi shell` for a session — there's no global environment to remember to deactivate afterward.
+
+## The running example
+
+The rest of this page uses a small script, `analysis.py`, that you should save into `my-analysis/`. It's a seeded Monte Carlo estimate of pi: everyone who runs it with the default sample count gets the exact same numbers, so the output below is not "an example" — it's what you'll actually see.
+
+```python title="analysis.py"
+"""Seeded Monte Carlo estimate of pi."""
+
+import argparse
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--samples", type=int, default=100_000)
+args = parser.parse_args()
+
+rng = np.random.default_rng(42)
+xy = rng.random((args.samples, 2))
+inside = (xy**2).sum(axis=1) <= 1.0
+running = 4 * np.cumsum(inside) / np.arange(1, args.samples + 1)
+estimate = running[-1]
+
+print(f"samples : {args.samples:,}")
+print(f"estimate: {estimate:.6f}")
+print(f"error   : {abs(estimate - np.pi):.6f} ({abs(estimate - np.pi) / np.pi:.4%})")
+
+plt.figure(figsize=(8, 4))
+plt.plot(running, lw=0.8)
+plt.axhline(np.pi, color="crimson", ls="--", label="pi")
+plt.xlabel("samples")
+plt.ylabel("estimate")
+plt.legend()
+plt.savefig("pi-estimate.png", dpi=120, bbox_inches="tight")
+print("wrote   : pi-estimate.png")
+```
+
+Run it the same way you ran `python -V` above:
+
+```bash
+pixi run python analysis.py
+```
+
+```text
+samples : 100,000
+estimate: 3.150080
+error   : 0.008487 (0.2702%)
+wrote   : pi-estimate.png
+```
+
+## Tasks
+
+Typing `pixi run python analysis.py` every time gets old, and it doesn't capture the `--samples` flag you might want for a quick check. Pixi tasks turn a command into a name, stored in the manifest, that anyone with the project can run.
+
+Add three of them:
+
+```bash
+pixi task add analyze "python analysis.py"
+pixi task add quick "python analysis.py --samples 2000" --description "Fast sanity check"
+pixi task add full "python analysis.py" --depends-on quick
+```
+
+Each call rewrites the manifest's `[tasks]` table:
+
+```toml title="pixi.toml"
+[tasks]
+analyze = "python analysis.py"
+quick = { cmd = "python analysis.py --samples 2000", description = "Fast sanity check" }
+full = { cmd = "python analysis.py", depends-on = ["quick"] }
+```
+
+Look at what happened to `quick` and `full`: pixi promoted them from a plain string to an inline table the moment they needed to carry something beyond the bare command — a `description`, a `depends-on`. `analyze` stays a one-line string because a command is all it is.
+
+`full` depends on `quick`, so running it runs the chain:
+
+```bash
+pixi run full
+```
+
+```text
+✨ Pixi task (quick): python analysis.py --samples 2000: (Fast sanity check)
+samples : 2,000
+estimate: 3.138000
+error   : 0.003593 (0.1144%)
+wrote   : pi-estimate.png
+
+✨ Pixi task (full): python analysis.py
+samples : 100,000
+estimate: 3.150080
+error   : 0.008487 (0.2702%)
+wrote   : pi-estimate.png
+```
+
+`quick` runs first, in full, then `full` itself runs. Chain as many tasks together as the workflow needs; pixi runs each dependency once, in order, before the task you asked for.
+
+### Listing tasks
+
+Run `pixi run` with no task name, and pixi lists what's available:
+
+```bash
+pixi run
+```
+
+```text
+Available tasks:
+	analyze
+	full
+	quick
+```
+
+Names only — no descriptions. For those, ask `pixi task list` instead:
+
+```bash
+pixi task list
+```
+
+```text
+Tasks that can run on this machine:
+-----------------------------------
+analyze (by design), full (by design), quick (by design)
+Task   Description
+quick  Fast sanity check
+```
+
+## Why this matters
+
+Tasks ship *with* the project, inside `pixi.toml`, not in your shell history or a README someone forgot to update. The next person who clones `my-analysis` doesn't read documentation to learn how to reproduce your result — they run `pixi run analyze`. They never dig through your terminal scrollback, and they never have to reverse-engineer a Makefile to figure out what `make` actually does here.
+
+!!! example "A real one: this site"
+
+    The guidelines site you are reading is itself a pixi workspace. Its
+    `pixi.toml` defines `start` for local preview, `rtd-publish` for the
+    Read the Docs build, and a `release` task that uses `depends-on` to run
+    `set-default-repo` first. Every page here was built by `pixi run`.
+
+### Your turn
+
+Add a task called `clean` that deletes `pi-estimate.png`, then chain it so that
+`analyze` always starts from a clean slate.
+
+??? success "Solution"
+
+    ```bash
+    pixi task add clean "rm -f pi-estimate.png"
+    pixi task add fresh "python analysis.py" --depends-on clean
+    pixi run fresh
+    ```

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -563,10 +563,13 @@ pixi search '*humanize*'
 
 ```text
 Using channels: conda-forge
-humanize (60 versions)
+humanize (N versions)
   4.16.0 pyhd8ed1ab_0 [noarch] conda-forge
   4.15.0 pyhd8ed1ab_0 [noarch] conda-forge
 ```
+
+The version count grows with every release, so yours will differ. What matters is that the package was found at all.
+
 
 `humanize` is, in fact, on conda-forge — the `--pypi` example earlier in this section demonstrates the mechanics of adding a PyPI dependency, not a package with nowhere else to come from. For a package genuinely absent from conda-forge, `pixi search` says so plainly instead of silently returning nothing:
 

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -91,3 +91,103 @@ Once you have pixi installed, you can verify by running the command below
 ```bash
 pixi --version
 ```
+
+## Your first project
+
+Create a new project with `pixi init`, then move into it:
+
+```bash
+pixi init my-analysis
+cd my-analysis
+```
+
+pixi creates a small tree:
+
+```text
+my-analysis/
+├── .gitattributes
+├── .gitignore
+└── pixi.toml
+```
+
+`pixi.toml` is the manifest — the file you edit by hand to describe the project. This is exactly what `pixi init` writes into it:
+
+```toml title="pixi.toml"
+[workspace]
+channels = ["conda-forge"]  # (1)!
+name = "my-analysis"  # (2)!
+platforms = ["osx-arm64"]  # (3)!
+version = "0.1.0"  # (4)!
+
+[tasks]
+
+[dependencies]
+```
+
+1. `channels` says where packages come from, in priority order. `conda-forge` is the default.
+2. `name` identifies the project. `pixi init` took it from the argument you gave it.
+3. `platforms` says which platform(s) the lock file must cover. Add more (`linux-64`, `win-64`, `linux-aarch64`, ...) so the project also solves on other machines.
+4. `version` is the project's own version, independent of anything you later publish.
+
+`[tasks]` and `[dependencies]` are generated empty — pixi always writes both tables, ready for you to fill in as you add tasks and packages later in this guide.
+
+`authors` and `description` are optional fields you can add yourself; pixi 0.73.0's `init` does not write them, however you may see them listed in older tutorials.
+
+!!! note "`[workspace]` or `[project]`?"
+
+    Older pixi tutorials show a `[project]` table. It was renamed to
+    `[workspace]`. `[project]` still parses, but pixi 0.73.0 emits a deprecation
+    warning telling you to replace it. Use `[workspace]` in new projects.
+
+### Adding dependencies
+
+A project with no dependencies doesn't do much. Add the three packages this analysis needs:
+
+```bash
+pixi add python numpy matplotlib
+```
+
+```text
+✔ Added python >=3.14.6,<3.15
+✔ Added numpy >=2.5.1,<3
+✔ Added matplotlib >=3.11.1,<4
+```
+
+Notice that `python` went in unpinned — the command was `pixi add python`, not `pixi add python=3.11`. pixi's default pinning strategy already wrote the `>=3.14.6,<3.15` range for you, so you rarely need to pin versions by hand.
+
+`pixi.toml` now has a filled-in `[dependencies]` table:
+
+```toml title="pixi.toml"
+[dependencies]
+python = ">=3.14.6,<3.15"
+numpy = ">=2.5.1,<3"
+matplotlib = ">=3.11.1,<4"
+```
+
+## What just happened
+
+Look at the directory again:
+
+```text
+my-analysis/
+├── .gitattributes
+├── .gitignore
+├── .pixi/
+├── pixi.lock
+└── pixi.toml
+```
+
+Two new things appeared: `pixi.lock` and `.pixi/`. Their sizes on disk tell you most of what you need to know about what each one is for:
+
+```text
+      12 pixi.toml
+    1184 pixi.lock
+```
+
+`pixi.toml` barely grew — it's still three short version ranges. `pixi.lock` is nearly a hundred times larger. That gap is the whole model:
+
+- **`pixi.toml` is the manifest: your intent.** Version ranges, written by you, small and readable, meant to be reviewed in a diff.
+- **`pixi.lock` is the lock file: the exact solution.** Every package, every exact version, build string and hash, resolved for every platform listed in `platforms`. pixi writes and maintains it; you never hand-edit it.
+- **`.pixi/` is the environment directory: a disposable build product.** It's the actual environment — interpreter and packages unpacked on disk — built from `pixi.lock`. It's gitignored, and pixi can rebuild it from the lock file at any time.
+
+Commit `pixi.toml` and `pixi.lock`. Never commit `.pixi/`.

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -588,3 +588,148 @@ fastqc = { version = ">=0.12.1,<0.13", channel = "bioconda" }
 ```
 
 Notice what landed in the manifest: not a bare version string like the other entries in `[dependencies]`, but a table with a `channel` key. `channel::package` at the command line isn't just a lookup hint — pixi records the channel choice in `pixi.toml`, so a collaborator reading the manifest (or the solver resolving it later) knows `fastqc` comes from `bioconda` specifically, not wherever else it happens to be found.
+
+## Inspecting your environment
+
+At this point `my-analysis` has grown past what fits in your head: two environments, three conda dependencies, a PyPI dependency, three tasks. The next time something looks wrong — a version you didn't expect, a package you can't find — you need a fast answer to "what did pixi actually install, and why is that package here?" Four commands answer that.
+
+`pixi list` shows every package installed in the default environment, one row each, with version, build string, size, and where it came from:
+
+```bash
+pixi list
+```
+
+Add `-e` to ask about a named environment instead of the default one:
+
+```bash
+pixi list -e dev
+```
+
+`pixi list` is flat — it tells you *what* is installed, not *why*. `pixi tree` answers the second question, showing the dependency graph so you can see which of your direct dependencies pulled in a package you never asked for:
+
+```bash
+pixi tree
+```
+
+```text
+Installed for: osx-arm64
+├── humanize 4.16.0
+├── matplotlib 3.11.1
+│   ├── matplotlib-base 3.11.1
+│   │   ├── contourpy 1.3.3
+│   │   │   ├── numpy 2.5.1
+│   │   │   │   ├── python 3.14.6
+```
+
+Read it top to bottom: `numpy` isn't a top-level entry here because nothing above it is looking for it directly — it's pulled in as a dependency of `contourpy`, which is pulled in by `matplotlib-base`, which is pulled in by `matplotlib`, which you did add directly. When a version you didn't pin shows up in `pixi.lock`, `pixi tree` is how you find which of your dependencies is responsible.
+
+Neither command tells you which environments exist or what's in each of them at a glance. `pixi info` does:
+
+```bash
+pixi info
+```
+
+```text
+Environments
+------------
+        Environment: default
+           Features: default
+           Channels: conda-forge
+   Dependency count: 3
+       Dependencies: python, numpy, matplotlib
+  PyPI Dependencies: humanize
+   Target platforms: osx-arm64
+    Prefix location: ~/my-analysis/.pixi/envs/default
+              Tasks: analyze, full, quick
+
+        Environment: dev
+           Features: dev, default
+           Channels: conda-forge
+   Dependency count: 4
+       Dependencies: pytest, python, numpy, matplotlib
+```
+
+This is the summary to reach for first when the question is about environments rather than individual packages: it lists every environment in the workspace, the features each one composes, the dependencies and tasks that come with it, and where its files live on disk — all without picking one environment ahead of time the way `pixi list -e` requires.
+
+## Tools without a project
+
+Not everything you install needs to live inside a project. A linter, a formatter, a CLI utility you use across every repo you touch — none of that belongs in `my-analysis`'s `[dependencies]`, because it isn't part of what `my-analysis` needs to run. It's a tool *you* use, not something the project depends on.
+
+The old habit is to `pip install` a tool like that into whatever environment happens to be active. That's how you end up with "I pip-installed a linter into my analysis environment and broke it" — the tool's own dependencies collide with the project's, and now neither one solves cleanly. `pixi global install` avoids the collision entirely by giving each tool its own isolated environment under `~/.pixi`, completely separate from any project and from every other global tool:
+
+```bash
+pixi global install ruff
+```
+
+```text
+Global environments as specified in '~/.pixi/manifests/pixi-global.toml'
+└── ruff: 0.15.22
+    └─ exposes: ruff
+```
+
+`pixi global list` shows what you have installed globally and which commands each one exposes on your `PATH` — here, the `ruff` environment exposes a single `ruff` command. A tool with several entry points can expose more than one; `--expose` lets you control exactly which binaries from the installed package become available on your `PATH`, and under what name, rather than accepting all of them.
+
+Keep the distinction in mind: `pixi add` changes a project's manifest and lock file, checked into git, reproducible on any machine that clones the project. `pixi global install` changes state on *your* machine, outside any project — nothing about it is recorded in `my-analysis`, and a collaborator cloning your repository gets no trace of it. Reach for it for tools you personally use across projects, not for anything a project needs to run.
+
+## Migrating from conda
+
+If you're starting from an existing conda project rather than from scratch, pixi can read its `environment.yml` and generate a starting manifest instead of you re-declaring every dependency by hand. Given this file:
+
+```yaml title="environment.yml"
+name: old-analysis
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - numpy
+  - pip
+  - pip:
+      - humanize
+```
+
+Import it into a new pixi project:
+
+```bash
+pixi init --import environment.yml migrated
+```
+
+The generated `pixi.toml`:
+
+```toml title="pixi.toml"
+[workspace]
+channels = ["conda-forge"]
+name = "old-analysis"
+platforms = ["osx-arm64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+python = "3.11.*"
+numpy = "*"
+pip = "*"
+
+[pypi-dependencies]
+humanize = "*"
+```
+
+The translation follows a fixed pattern:
+
+| `environment.yml` | pixi manifest |
+| --- | --- |
+| `name:` | `[workspace] name` |
+| `channels:` | `[workspace] channels` |
+| `dependencies:` | `[dependencies]` |
+| `pip:` entries | `[pypi-dependencies]` |
+
+One thing to clean up by hand: the import carried `pip` itself into `[dependencies]`, because it was a literal entry in the source file's `dependencies:` list. Pixi doesn't need `pip` installed to manage `[pypi-dependencies]` — that entry is safe to delete.
+
+The versions in the generated manifest are also worth a second look. `python=3.11` became the range `3.11.*`, which is a reasonable translation. But `numpy` and `humanize`, which had no version pin in `environment.yml`, both became the wildcard `*` — accept whatever the solver finds today, with no lower bound at all. Treat the import as a starting point, not a finished manifest: replace `*` with real ranges for anything that matters, the same way you would for a dependency you added by hand with `pixi add`.
+
+If your old project instead tracked dependencies in a `requirements.txt`, don't import it one line at a time — piping it through `xargs` so that each package gets its own `pixi add --pypi` call runs a full dependency solve per line, which is slow and wasteful for a file with any real number of entries. Batch it into a single call instead:
+
+```bash
+pixi add --pypi $(tr '\n' ' ' < requirements.txt)
+```
+
+That resolves every package in one solve, the same way `pixi add python numpy matplotlib` did earlier on this page.

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -374,7 +374,7 @@ Add a task called `clean` that deletes `pi-estimate.png`, then chain it so that
 You've been told `pixi.lock` is "the exact solution." Look at one entry from it and see what that actually means. Find the `numpy` package pixi resolved for this project:
 
 ```bash
-grep -A 6 '^- conda: .*numpy-2.5.1' pixi.lock
+grep -A 8 '^- conda: .*numpy-2.5.1' pixi.lock
 ```
 
 ```yaml
@@ -395,7 +395,7 @@ Every field is more specific than what `pixi.toml` asked for:
 - `sha256` and `md5` are content hashes of the download itself. They let pixi (or anyone) verify that the bytes it just fetched are the bytes that were solved, not a package that was quietly rebuilt or repackaged under the same name and version.
 - `depends` is that package's own dependency list, exactly as conda-forge published it for this build — not something pixi invented. It's how the solver knew this build of numpy needed this Python ABI and this `liblapack` range in the first place.
 
-This block repeats once per package, once per platform in `platforms` — but not just for the three packages you named. `depends:` is recursive: numpy pulls in `python`, `libcxx`, `liblapack`, and each of those pulls in its own dependencies in turn, all the way down. `pixi.lock` records that whole transitive closure, not only the packages `pixi.toml` mentions by name — 89 conda package entries for this project, each with its own block like the one above. That's the gap between the two files: `pixi.toml` holds three version ranges you wrote by hand, about a dozen lines. `pixi.lock` holds the solved answer for the entire closure, sha256 and all: 1,184 lines.
+This block repeats once per package, once per platform in `platforms` — but not just for the three packages you named. `depends:` is recursive: numpy pulls in `python`, `libcxx`, `liblapack`, and each of those pulls in its own dependencies in turn, all the way down. `pixi.lock` records that whole transitive closure, not only the packages `pixi.toml` mentions by name — 81 conda package entries for this project, each with its own block like the one above. That's the gap between the two files: `pixi.toml` holds three version ranges you wrote by hand, about a dozen lines. `pixi.lock` holds the solved answer for the entire closure, sha256 and all: 1,184 lines.
 
 ### Proof: `.pixi/` is disposable
 
@@ -555,21 +555,17 @@ pixi run python -c "import humanize; print(humanize.__version__)"
 - Reach for `--pypi` when a package is not on conda-forge at all.
 - Both kinds land in the same `pixi.lock`. One file still pins the entire environment.
 
-Before reaching for `--pypi`, check conda-forge first — don't assume a package is missing just because you haven't seen it there. `pixi search` answers that directly:
+Before reaching for `--pypi`, check conda-forge first — don't assume a package is missing just because you haven't seen it there. Search with a glob (`*name*`), not the exact package name: conda-forge sometimes normalises names, so a PyPI `some-package` can turn up on conda-forge as `some_package`, and an exact-name search can miss it. `pixi search` answers that directly:
 
 ```bash
-pixi search humanize
+pixi search '*humanize*'
 ```
 
 ```text
 Using channels: conda-forge
-humanize-4.16.0-pyhd8ed1ab_0
-----------------------------
-
-Name                humanize
-Version             4.16.0
-Build               pyhd8ed1ab_0
-Size                71.17 KiB
+humanize (60 versions)
+  4.16.0 pyhd8ed1ab_0 [noarch] conda-forge
+  4.15.0 pyhd8ed1ab_0 [noarch] conda-forge
 ```
 
 `humanize` is, in fact, on conda-forge — the `--pypi` example earlier in this section demonstrates the mechanics of adding a PyPI dependency, not a package with nowhere else to come from. For a package genuinely absent from conda-forge, `pixi search` says so plainly instead of silently returning nothing:
@@ -584,7 +580,7 @@ Error:   × No packages found matching '*cowsay*'
   help: Try glob patterns like 'python*' or '*numpy*'
 ```
 
-Search with a glob (`*name*`), not the exact PyPI name: conda-forge sometimes normalises names, so a PyPI `some-package` can turn up on conda-forge as `some_package`. Search for the exact PyPI spelling and you can get a false negative — miss a package that's really there and reach for `--pypi` when you didn't need to. numpy, matplotlib, and anything like them belong in `[dependencies]`, not behind `--pypi`: split a compiled, interdependent stack like that across two separate solvers and you lose the one thing a single conda solve buys you — a solver that reasons about binary compatibility across the *whole* environment at once. Reach for `--pypi` only after checking conda-forge and coming up empty.
+numpy, matplotlib, and anything like them belong in `[dependencies]`, not behind `--pypi`: split a compiled, interdependent stack like that across two separate solvers and you lose the one thing a single conda solve buys you — a solver that reasons about binary compatibility across the *whole* environment at once. Reach for `--pypi` only after checking conda-forge and coming up empty.
 
 ### Packages from other channels
 
@@ -648,6 +644,7 @@ Installed for: osx-arm64
 Name                       Version      Build                      Size  Kind   Source
 _openmp_mutex              4.5          7_kmp_llvm             8.13 KiB  conda  https://conda.anaconda.org/conda-forge
 brotli                     1.2.0        h7d5ae5b_1            19.76 KiB  conda  https://conda.anaconda.org/conda-forge
+brotli-bin                 1.2.0        hc919400_1            18.19 KiB  conda  https://conda.anaconda.org/conda-forge
 bzip2                      1.0.8        hd037594_9           121.91 KiB  conda  https://conda.anaconda.org/conda-forge
 ca-certificates            2026.7.22    hbd8a1cb_0           128.69 KiB  conda  https://conda.anaconda.org/conda-forge
 ```

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -417,3 +417,98 @@ That's the payoff of the rule from earlier: `.pixi/` is a cache, rebuildable at 
 ### Which file guarantees what
 
 The manifest records what you asked for; the lock file records what you got. A collaborator who clones your project with `pixi.lock` intact gets the exact versions, builds, and hashes you resolved — the same numbers this page has been showing you. A collaborator who has only `pixi.toml` — say, because `pixi.lock` was gitignored by mistake — gets whatever the solver picks today, against whatever conda-forge and PyPI look like today. Those can be different environments even though the manifest never changed.
+
+## Beyond one environment
+
+Your users need `numpy` and `matplotlib` to run the analysis, nothing more. You, working on the project, also want `pytest` for tests, maybe a linter, maybe IPython for exploring interactively. Put all of that in one `[dependencies]` table and everyone who installs the project pulls your entire toolchain along with it — installs get slower, the solve gets harder, and "what does this need to run" gets muddied with "what do I need to work on it."
+
+Conda's usual answer is a second `environment-dev.yml`, maintained by hand alongside the first, and the two drift apart the moment someone forgets to update both. Pixi keeps the answer inside the one manifest and the one lock file: declare **features** — named groups of extra dependencies — then compose them into **environments**.
+
+Add `pytest` as a feature called `dev`, then create an environment that uses it:
+
+```bash
+pixi add --feature dev pytest
+pixi workspace environment add dev --feature dev
+```
+
+The first command's output looks almost like any other `pixi add`, with one difference:
+
+```text
+✔ Added pytest
+Added these only for feature: dev
+```
+
+`pytest` is now in the manifest, but no environment references the `dev` feature yet, so it isn't part of your project's default environment and isn't installed anywhere. A feature that no environment uses is inert, and pixi says so the next time it parses the manifest. That happens on the very next command, `pixi workspace environment add`, before that same command's own fix takes effect:
+
+```text
+ WARN Encountered 1 warning while parsing the manifest:
+  ⚠ The feature 'dev' is defined but not used in any environment. Dependencies
+  │ of unused features are not resolved or checked, and use wildcard (*)
+  │ version specifiers by default, disregarding any set `pinning-strategy`
+    ╭─[pixi.toml:17:10]
+ 16 │
+ 17 │ [feature.dev.dependencies]
+    ·          ───
+ 18 │ pytest = "*"
+    ╰────
+  help: Remove the feature from the manifest or add it to an environment
+
+✔ Added environment dev
+```
+
+(The exact line numbers depend on your manifest.) That ordering — a warning about a problem, immediately followed by the command that fixes it — looks backwards until you remember that pixi re-parses the whole manifest before acting on it. It read the orphaned `dev` feature left over from the previous command, flagged it, and then this command wired that feature into an environment: the very fix the warning asked for. Seeing the warning land between the two commands is what makes the two-step sequence — add to a feature, then attach the feature to an environment — feel purposeful instead of arbitrary.
+
+The manifest now carries both pieces:
+
+```toml title="pixi.toml"
+[feature.dev.dependencies]
+pytest = "*"
+
+[environments]
+dev = ["dev"]
+```
+
+### Crossing the environment boundary
+
+Ask each environment what it can see. Inside `dev`:
+
+```bash
+pixi run -e dev pytest --version
+```
+
+```text
+pytest 9.1.1
+```
+
+Without `-e dev` — the default environment, the one everyone gets:
+
+```bash
+pixi run pytest --version
+```
+
+```text
+pytest: command not found
+
+Available tasks:
+	analyze
+	full
+	quick
+```
+
+That failure is the point, not a bug to work around. The default environment is exactly what a user gets the moment they clone `my-analysis` and run `pixi run analyze`: python, numpy, matplotlib, and nothing you added only for yourself.
+
+`dev = ["dev"]` under `[environments]` is a list of feature names — here, just the one. Yet the `dev` environment has `numpy` and `matplotlib` too, not only `pytest`: every environment implicitly includes the `default` feature — whatever lives in the bare `[dependencies]` table — unless you explicitly opt out with `--no-default-feature`. That's the whole rule. `dev` isn't `pytest` in isolation; it's `default` plus `pytest`.
+
+### Your turn
+
+Create a `repl` feature containing `ipython`, wire it into an environment of the
+same name, and confirm the default environment still cannot see it.
+
+??? success "Solution"
+
+    ```bash
+    pixi add --feature repl ipython
+    pixi workspace environment add repl --feature repl
+    pixi run -e repl ipython --version
+    pixi run ipython --version   # command not found
+    ```

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -364,3 +364,56 @@ Add a task called `clean` that deletes `pi-estimate.png`, then chain it so that
     pixi task add fresh "python analysis.py" --depends-on clean
     pixi run fresh
     ```
+
+## The lock file
+
+You've been told `pixi.lock` is "the exact solution." Look at one entry from it and see what that actually means. Find the `numpy` package pixi resolved for this project:
+
+```bash
+grep -A 8 "numpy-2.5.1-py314hb79c6fa_0.conda$" pixi.lock
+```
+
+```yaml
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.1-py314hb79c6fa_0.conda
+  sha256: 3aa853ec05e6fe6b660be354fd05ab2a89b2e6cc6346612a6c75a18f38f62c3d
+  md5: 3587914062d5537dde5fa8c2131cf624
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - python_abi 3.14.* *_cp314
+  - liblapack >=3.9.0,<4.0a0
+```
+
+Every field is more specific than what `pixi.toml` asked for:
+
+- The `conda:` line is a full URL — channel, platform, package name, version, *and build string* (`py314hb79c6fa_0`). The build string distinguishes this exact build of numpy 2.5.1 from any other build of the same version compiled against a different Python or a different BLAS.
+- `sha256` and `md5` are content hashes of the download itself. They let pixi (or anyone) verify that the bytes it just fetched are the bytes that were solved, not a package that was quietly rebuilt or repackaged under the same name and version.
+- `depends` is that package's own dependency list, exactly as conda-forge published it for this build — not something pixi invented. It's how the solver knew this build of numpy needed this Python ABI and this `liblapack` range in the first place.
+
+This block repeats — once per package, once per platform in `platforms` — for every one of the three packages you added. That's the whole file: `pixi.toml` holds three version ranges you wrote by hand, about a dozen lines. `pixi.lock` holds the solved answer for all of them, sha256 and all: 1,184 lines. The manifest is what you asked for; the lock is what you got.
+
+### Proof: `.pixi/` is disposable
+
+Earlier, this page called `.pixi/` a disposable build product. Prove it. Delete it and rerun the task that depends on it:
+
+```bash
+rm -rf .pixi
+pixi run analyze
+```
+
+```text
+✨ Pixi task (analyze): python analysis.py
+samples : 100,000
+estimate: 3.150080
+error   : 0.008487 (0.2702%)
+wrote   : pi-estimate.png
+```
+
+No error, no re-solve, no prompt — the same four lines you saw the first time you ran `analyze`. Pixi noticed the environment directory was gone, reinstalled every package straight from `pixi.lock`, and then ran the task, all inside that one `pixi run` call. Nothing about the *content* of the run changed, because nothing about the lock file changed.
+
+That's the payoff of the rule from earlier: `.pixi/` is a cache, rebuildable at any time from `pixi.lock`. `pixi.toml` and `pixi.lock` *are* the project. This is why `.pixi/` is gitignored, and why a dead laptop, a wiped CI runner, or a fresh clone is a non-event — `pixi run` rebuilds the exact same environment from the lock file every time.
+
+### Which file guarantees what
+
+The manifest records what you asked for; the lock file records what you got. A collaborator who clones your project with `pixi.lock` intact gets the exact versions, builds, and hashes you resolved — the same numbers this page has been showing you. A collaborator who has only `pixi.toml` — say, because `pixi.lock` was gitignored by mistake — gets whatever the solver picks today, against whatever conda-forge and PyPI look like today. Those can be different environments even though the manifest never changed.

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -817,7 +817,7 @@ A UW SSEC advanced pixi guide covering these topics in depth is planned but not 
     both:
 
     ```toml
-    # Task with required arguments
+    # Task with a required argument
     [tasks.greet]
     args = ["name"]
     cmd = "echo Hello, {{ name }}!"
@@ -828,7 +828,7 @@ A UW SSEC advanced pixi guide covering these topics in depth is planned but not 
     { "arg" = "project", "default" = "my-app" },
     { "arg" = "mode", "default" = "development" },
     ]
-    cmd = "echo Building {{ project }} in {{ mode }} mode"
+    cmd = "echo 'Building {{ project }} in {{ mode }} mode'"
 
     # Task with mixed required and optional arguments
     [tasks.deploy]
@@ -836,13 +836,27 @@ A UW SSEC advanced pixi guide covering these topics in depth is planned but not 
     cmd = "echo Deploying {{ service }} to {{ environment }}"
     ```
 
-    Run them by passing the arguments as flags:
+    The `build` command's echoed string is quoted. Without the quotes, pixi's
+    task shell treats the bare word `in` as a reserved word and refuses to
+    parse the command — a small trap worth knowing about if you write a task
+    command that happens to contain `in` unquoted.
+
+    Arguments are positional, not flags — pass values in the order they're
+    declared:
 
     ```bash
-    pixi run greet --name Bob
-    pixi run build --project my-app --mode production
-    pixi run deploy --service my-service --environment production
+    pixi run greet Bob
+    pixi run build
+    pixi run build my-app production
+    pixi run deploy api
+    pixi run deploy api production
     ```
+
+    Because arguments are positional, there's no way to skip ahead to a later
+    one: to override `mode` (the second argument to `build`) you must also
+    supply `project` (the first), even if you just want the default. That's
+    why `pixi run build my-app production` passes `my-app` explicitly instead
+    of skipping straight to `production`.
 
     This is beyond fundamentals — the UW SSEC advanced pixi guide will cover it
     in more depth.

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -177,7 +177,11 @@ my-analysis/
 └── pixi.toml
 ```
 
-Two new things appeared: `pixi.lock` and `.pixi/`. Their sizes on disk tell you most of what you need to know about what each one is for:
+Two new things appeared: `pixi.lock` and `.pixi/`. Count the lines in each — the gap between them tells you most of what you need to know about what each one is for:
+
+```bash
+wc -l pixi.toml pixi.lock
+```
 
 ```text
       12 pixi.toml
@@ -341,7 +345,7 @@ Task   Description
 quick  Fast sanity check
 ```
 
-## Why this matters
+### Why this matters
 
 Tasks ship *with* the project, inside `pixi.toml`, not in your shell history or a README someone forgot to update. The next person who clones `my-analysis` doesn't read documentation to learn how to reproduce your result — they run `pixi run analyze`. They never dig through your terminal scrollback, and they never have to reverse-engineer a Makefile to figure out what `make` actually does here.
 
@@ -370,7 +374,7 @@ Add a task called `clean` that deletes `pi-estimate.png`, then chain it so that
 You've been told `pixi.lock` is "the exact solution." Look at one entry from it and see what that actually means. Find the `numpy` package pixi resolved for this project:
 
 ```bash
-grep -A 8 "numpy-2.5.1-py314hb79c6fa_0.conda$" pixi.lock
+grep -A 6 '^- conda: .*numpy-2.5.1' pixi.lock
 ```
 
 ```yaml
@@ -391,7 +395,7 @@ Every field is more specific than what `pixi.toml` asked for:
 - `sha256` and `md5` are content hashes of the download itself. They let pixi (or anyone) verify that the bytes it just fetched are the bytes that were solved, not a package that was quietly rebuilt or repackaged under the same name and version.
 - `depends` is that package's own dependency list, exactly as conda-forge published it for this build — not something pixi invented. It's how the solver knew this build of numpy needed this Python ABI and this `liblapack` range in the first place.
 
-This block repeats — once per package, once per platform in `platforms` — for every one of the three packages you added. That's the whole file: `pixi.toml` holds three version ranges you wrote by hand, about a dozen lines. `pixi.lock` holds the solved answer for all of them, sha256 and all: 1,184 lines.
+This block repeats once per package, once per platform in `platforms` — but not just for the three packages you named. `depends:` is recursive: numpy pulls in `python`, `libcxx`, `liblapack`, and each of those pulls in its own dependencies in turn, all the way down. `pixi.lock` records that whole transitive closure, not only the packages `pixi.toml` mentions by name — 89 conda package entries for this project, each with its own block like the one above. That's the gap between the two files: `pixi.toml` holds three version ranges you wrote by hand, about a dozen lines. `pixi.lock` holds the solved answer for the entire closure, sha256 and all: 1,184 lines.
 
 ### Proof: `.pixi/` is disposable
 
@@ -515,7 +519,7 @@ same name, and confirm the default environment still cannot see it.
 
 ## conda and PyPI in one project
 
-Not everything you want lives on conda-forge. Pixi can pull from PyPI in the same project, using the same lock file, without reaching for `pip install` on the side. Add `humanize` — a small package for formatting numbers and dates that has no conda-forge build — with `--pypi`:
+Not everything you want lives on conda-forge. Pixi can pull from PyPI in the same project, using the same lock file, without reaching for `pip install` on the side. To see how that mechanism works, add `humanize` — a small package for formatting numbers and dates — with `--pypi`:
 
 ```bash
 pixi add --pypi humanize
@@ -551,11 +555,49 @@ pixi run python -c "import humanize; print(humanize.__version__)"
 - Reach for `--pypi` when a package is not on conda-forge at all.
 - Both kinds land in the same `pixi.lock`. One file still pins the entire environment.
 
-`humanize` earns its place in this example because it genuinely has no conda-forge build — there's no other way to get it into the project. numpy, matplotlib, and anything like them belong in `[dependencies]`, not behind `--pypi`: split a compiled, interdependent stack like that across two separate solvers and you lose the one thing a single conda solve buys you — a solver that reasons about binary compatibility across the *whole* environment at once. Reach for `--pypi` only after checking conda-forge and coming up empty.
+Before reaching for `--pypi`, check conda-forge first — don't assume a package is missing just because you haven't seen it there. `pixi search` answers that directly:
+
+```bash
+pixi search humanize
+```
+
+```text
+Using channels: conda-forge
+humanize-4.16.0-pyhd8ed1ab_0
+----------------------------
+
+Name                humanize
+Version             4.16.0
+Build               pyhd8ed1ab_0
+Size                71.17 KiB
+```
+
+`humanize` is, in fact, on conda-forge — the `--pypi` example earlier in this section demonstrates the mechanics of adding a PyPI dependency, not a package with nowhere else to come from. For a package genuinely absent from conda-forge, `pixi search` says so plainly instead of silently returning nothing:
+
+```bash
+pixi search '*cowsay*'
+```
+
+```text
+Using channels: conda-forge
+Error:   × No packages found matching '*cowsay*'
+  help: Try glob patterns like 'python*' or '*numpy*'
+```
+
+Search with a glob (`*name*`), not the exact PyPI name: conda-forge sometimes normalises names, so a PyPI `some-package` can turn up on conda-forge as `some_package`. Search for the exact PyPI spelling and you can get a false negative — miss a package that's really there and reach for `--pypi` when you didn't need to. numpy, matplotlib, and anything like them belong in `[dependencies]`, not behind `--pypi`: split a compiled, interdependent stack like that across two separate solvers and you lose the one thing a single conda solve buys you — a solver that reasons about binary compatibility across the *whole* environment at once. Reach for `--pypi` only after checking conda-forge and coming up empty.
 
 ### Packages from other channels
 
-`conda-forge` isn't the only channel, and it isn't always where a package lives. `bioconda`, for example, hosts a large share of the bioinformatics tooling that research-computing users reach for — tools like `fastqc` that conda-forge doesn't carry. Add the channel to the workspace first:
+`conda-forge` isn't the only channel, and it isn't always where a package lives. `bioconda`, for example, hosts a large share of the bioinformatics tooling that research-computing users reach for — tools like `fastqc` that conda-forge doesn't carry.
+
+A Monte Carlo estimate of pi has no reason to depend on a bioinformatics tool, so this is a detour from `my-analysis`. Set up a separate scratch project just to see how channels work, the same way the migration section later on this page uses its own throwaway project rather than folding into the running example:
+
+```bash
+pixi init scratch-bio
+cd scratch-bio
+```
+
+Add the channel to the workspace first:
 
 ```bash
 pixi workspace channel add bioconda
@@ -589,6 +631,8 @@ fastqc = { version = ">=0.12.1,<0.13", channel = "bioconda" }
 
 Notice what landed in the manifest: not a bare version string like the other entries in `[dependencies]`, but a table with a `channel` key. `channel::package` at the command line isn't just a lookup hint — pixi records the channel choice in `pixi.toml`, so a collaborator reading the manifest (or the solver resolving it later) knows `fastqc` comes from `bioconda` specifically, not wherever else it happens to be found.
 
+`scratch-bio` was only for this detour. The rest of the page returns to `my-analysis`, which never gained a `bioconda` channel or a `fastqc` dependency — `cd` back into it before continuing.
+
 ## Inspecting your environment
 
 At this point `my-analysis` has grown past what fits in your head: two environments, three conda dependencies, a PyPI dependency, three tasks. The next time something looks wrong — a version you didn't expect, a package you can't find — you need a fast answer to "what did pixi actually install, and why is that package here?" Four commands answer that.
@@ -597,6 +641,15 @@ At this point `my-analysis` has grown past what fits in your head: two environme
 
 ```bash
 pixi list
+```
+
+```text
+Installed for: osx-arm64
+Name                       Version      Build                      Size  Kind   Source
+_openmp_mutex              4.5          7_kmp_llvm             8.13 KiB  conda  https://conda.anaconda.org/conda-forge
+brotli                     1.2.0        h7d5ae5b_1            19.76 KiB  conda  https://conda.anaconda.org/conda-forge
+bzip2                      1.0.8        hd037594_9           121.91 KiB  conda  https://conda.anaconda.org/conda-forge
+ca-certificates            2026.7.22    hbd8a1cb_0           128.69 KiB  conda  https://conda.anaconda.org/conda-forge
 ```
 
 Add `-e` to ask about a named environment instead of the default one:
@@ -743,7 +796,7 @@ If your old project instead tracked dependencies in a `requirements.txt`, don't 
 pixi add --pypi $(tr '\n' ' ' < requirements.txt)
 ```
 
-That resolves every package in one solve, the same way `pixi add python numpy matplotlib` did earlier on this page.
+That resolves every package in one solve, the same way `pixi add python numpy matplotlib` did earlier on this page. It only works cleanly on a plain list of package names, though — a `requirements.txt` with comment lines (`# ...`) or `-r other-requirements.txt` includes will get passed straight through to `pixi add --pypi` as if they were package names and fail. Clean those out, or generate the argument list some other way, before batching a file that has them.
 
 ## Cheat sheet
 
@@ -766,7 +819,7 @@ Every command below appeared earlier on this page. Use this table to jump straig
 
 | Conda/Mamba | Pixi |
 | --- | --- |
-| `conda create -n myenv python=3.11` | `pixi init myproject` then `pixi add python=3.11` |
+| `conda create -n myenv python=3.11` | `pixi init myproject` then `pixi add python` |
 | `conda activate myenv` | `pixi shell` |
 | `conda install numpy` | `pixi add numpy` |
 | `conda run -n myenv python script.py` | `pixi run python script.py` |
@@ -777,7 +830,7 @@ Every command below appeared earlier on this page. Use this table to jump straig
 This page covers what you need for a single project with one or two environments. Pixi has more to offer once that stops being enough:
 
 - [`pyproject.toml` integration](https://pixi.sh/latest/python/pyproject_toml/) for package maintainers who want pixi to manage a Python package's build and publish workflow instead of keeping a separate `pixi.toml`.
-- [Multi-platform locking](https://pixi.sh/latest/workspace/multi_platform/) with `pixi workspace platform add`, so `pixi.lock` covers machines beyond the one you ran `pixi init` on.
+- [Multi-platform locking](https://pixi.sh/latest/workspace/multi_platform_configuration/) with `pixi workspace platform add`, so `pixi.lock` covers machines beyond the one you ran `pixi init` on.
 - [CI with `setup-pixi`](https://github.com/prefix-dev/setup-pixi) and `locked: true`, so a pipeline fails loudly instead of silently re-solving against a channel that has moved on since you last committed.
 - [Multiple environments in depth](https://pixi.sh/latest/workspace/multi_environment/), including solve groups, which go beyond the single `dev` example on this page.
 

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -391,7 +391,7 @@ Every field is more specific than what `pixi.toml` asked for:
 - `sha256` and `md5` are content hashes of the download itself. They let pixi (or anyone) verify that the bytes it just fetched are the bytes that were solved, not a package that was quietly rebuilt or repackaged under the same name and version.
 - `depends` is that package's own dependency list, exactly as conda-forge published it for this build — not something pixi invented. It's how the solver knew this build of numpy needed this Python ABI and this `liblapack` range in the first place.
 
-This block repeats — once per package, once per platform in `platforms` — for every one of the three packages you added. That's the whole file: `pixi.toml` holds three version ranges you wrote by hand, about a dozen lines. `pixi.lock` holds the solved answer for all of them, sha256 and all: 1,184 lines. The manifest is what you asked for; the lock is what you got.
+This block repeats — once per package, once per platform in `platforms` — for every one of the three packages you added. That's the whole file: `pixi.toml` holds three version ranges you wrote by hand, about a dozen lines. `pixi.lock` holds the solved answer for all of them, sha256 and all: 1,184 lines.
 
 ### Proof: `.pixi/` is disposable
 
@@ -410,7 +410,7 @@ error   : 0.008487 (0.2702%)
 wrote   : pi-estimate.png
 ```
 
-No error, no re-solve, no prompt — the same four lines you saw the first time you ran `analyze`. Pixi noticed the environment directory was gone, reinstalled every package straight from `pixi.lock`, and then ran the task, all inside that one `pixi run` call. Nothing about the *content* of the run changed, because nothing about the lock file changed.
+No error, no re-solve, no prompt — and the results match every other run of this same seeded script on this page. Pixi noticed the environment directory was gone, reinstalled every package straight from `pixi.lock`, and then ran the task, all inside that one `pixi run` call. Nothing about the *content* of the run changed, because nothing about the lock file changed.
 
 That's the payoff of the rule from earlier: `.pixi/` is a cache, rebuildable at any time from `pixi.lock`. `pixi.toml` and `pixi.lock` *are* the project. This is why `.pixi/` is gitignored, and why a dead laptop, a wiped CI runner, or a fresh clone is a non-event — `pixi run` rebuilds the exact same environment from the lock file every time.
 

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -744,3 +744,111 @@ pixi add --pypi $(tr '\n' ' ' < requirements.txt)
 ```
 
 That resolves every package in one solve, the same way `pixi add python numpy matplotlib` did earlier on this page.
+
+## Cheat sheet
+
+### CLI commands and the manifest
+
+Every command below appeared earlier on this page. Use this table to jump straight from a command to the manifest table it writes.
+
+| Command | Writes to `pixi.toml` |
+| --- | --- |
+| `pixi init <name>` | Creates `[workspace]`, `[tasks]`, `[dependencies]` |
+| `pixi add numpy` | `[dependencies] numpy = ">=…"` |
+| `pixi add --pypi humanize` | `[pypi-dependencies] humanize = ">=…"` |
+| `pixi add --feature dev pytest` | `[feature.dev.dependencies] pytest = "*"` |
+| `pixi workspace environment add dev --feature dev` | `[environments] dev = ["dev"]` |
+| `pixi workspace channel add bioconda` | `[workspace] channels` gains `bioconda` |
+| `pixi task add analyze "python analysis.py"` | `[tasks] analyze = "…"` |
+| `pixi task add full "…" --depends-on quick` | `[tasks] full = { cmd = "…", depends-on = ["quick"] }` |
+
+### Coming from conda
+
+| Conda/Mamba | Pixi |
+| --- | --- |
+| `conda create -n myenv python=3.11` | `pixi init myproject` then `pixi add python=3.11` |
+| `conda activate myenv` | `pixi shell` |
+| `conda install numpy` | `pixi add numpy` |
+| `conda run -n myenv python script.py` | `pixi run python script.py` |
+| `conda env export > environment.yaml` | Share `pixi.toml` **and** `pixi.lock` |
+
+## Going further
+
+This page covers what you need for a single project with one or two environments. Pixi has more to offer once that stops being enough:
+
+- [`pyproject.toml` integration](https://pixi.sh/latest/python/pyproject_toml/) for package maintainers who want pixi to manage a Python package's build and publish workflow instead of keeping a separate `pixi.toml`.
+- [Multi-platform locking](https://pixi.sh/latest/workspace/multi_platform/) with `pixi workspace platform add`, so `pixi.lock` covers machines beyond the one you ran `pixi init` on.
+- [CI with `setup-pixi`](https://github.com/prefix-dev/setup-pixi) and `locked: true`, so a pipeline fails loudly instead of silently re-solving against a channel that has moved on since you last committed.
+- [Multiple environments in depth](https://pixi.sh/latest/workspace/multi_environment/), including solve groups, which go beyond the single `dev` example on this page.
+
+A UW SSEC advanced pixi guide covering these topics in depth is planned but not yet available.
+
+## Appendices
+
+??? note "Appendix A · Platform-specific dependencies (beyond fundamentals)"
+
+    Restrict a dependency to a specific platform with a `[target.*.dependencies]`
+    table. Pixi only installs these on the matching platform, which is useful for
+    compilers and other system-level packages that don't apply everywhere:
+
+    ```toml
+    [dependencies]
+    python = "3.11.*"
+
+    [target.linux-64.dependencies]
+    # Linux-specific packages
+    gcc = "*"
+
+    [target.win-64.dependencies]
+    # Windows-specific packages
+    vs2022_win-64 = "*"
+
+    [target.osx-arm64.dependencies]
+    # macOS ARM-specific packages
+    ```
+
+    This is beyond fundamentals — the UW SSEC advanced pixi guide will cover it
+    in more depth.
+
+??? note "Appendix B · Task arguments (beyond fundamentals)"
+
+    Tasks can take arguments instead of hard-coding every value into the
+    command. An argument can be required, optional with a default, or a mix of
+    both:
+
+    ```toml
+    # Task with required arguments
+    [tasks.greet]
+    args = ["name"]
+    cmd = "echo Hello, {{ name }}!"
+
+    # Task with optional arguments (default values)
+    [tasks.build]
+    args = [
+    { "arg" = "project", "default" = "my-app" },
+    { "arg" = "mode", "default" = "development" },
+    ]
+    cmd = "echo Building {{ project }} in {{ mode }} mode"
+
+    # Task with mixed required and optional arguments
+    [tasks.deploy]
+    args = ["service", { "arg" = "environment", "default" = "staging" }]
+    cmd = "echo Deploying {{ service }} to {{ environment }}"
+    ```
+
+    Run them by passing the arguments as flags:
+
+    ```bash
+    pixi run greet --name Bob
+    pixi run build --project my-app --mode production
+    pixi run deploy --service my-service --environment production
+    ```
+
+    This is beyond fundamentals — the UW SSEC advanced pixi guide will cover it
+    in more depth.
+
+## Conclusion
+
+Pixi's core idea is that the project, not a named global environment, is the unit of reproducibility: the manifest and the lock file live with the code, travel with it in git, and rebuild the same environment on any machine. Coming from conda, the adjustment isn't a new set of commands to memorize so much as a shift in what you keep in your head — you stop tracking which environment is active and start trusting that `pixi run` and `pixi shell` always give you the right one.
+
+That shift is what pays off. A collaborator who clones your repository gets your exact environment, not a fresh solve against whatever conda-forge and PyPI look like today, and neither of you has to remember to keep an `environment.yml` in sync with reality by hand.

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -512,3 +512,79 @@ same name, and confirm the default environment still cannot see it.
     pixi run -e repl ipython --version
     pixi run ipython --version   # command not found
     ```
+
+## conda and PyPI in one project
+
+Not everything you want lives on conda-forge. Pixi can pull from PyPI in the same project, using the same lock file, without reaching for `pip install` on the side. Add `humanize` — a small package for formatting numbers and dates that has no conda-forge build — with `--pypi`:
+
+```bash
+pixi add --pypi humanize
+```
+
+```text
+✔ Added humanize >=4.16.0, <5
+Added these as pypi-dependencies.
+```
+
+That second line matters: `pixi add python numpy matplotlib` all went into `[dependencies]`, but this one went somewhere new.
+
+```toml title="pixi.toml"
+[pypi-dependencies]
+humanize = ">=4.16.0, <5"
+```
+
+It behaves like any other dependency once it's there:
+
+```bash
+pixi run python -c "import humanize; print(humanize.__version__)"
+```
+
+```text
+4.16.0
+```
+
+### conda-forge first
+
+`--pypi` is easy to reach for out of habit, but it isn't the default choice — `[dependencies]` is. The rule:
+
+- Prefer conda-forge (`[dependencies]`) for compiled and scientific-stack packages — numpy, matplotlib, scipy, anything with C or Fortran underneath. One solver then reasons about binary compatibility across the whole environment, which is what prevents ABI mismatches.
+- Reach for `--pypi` when a package is not on conda-forge at all.
+- Both kinds land in the same `pixi.lock`. One file still pins the entire environment.
+
+`humanize` earns its place in this example because it genuinely has no conda-forge build — there's no other way to get it into the project. numpy, matplotlib, and anything like them belong in `[dependencies]`, not behind `--pypi`: split a compiled, interdependent stack like that across two separate solvers and you lose the one thing a single conda solve buys you — a solver that reasons about binary compatibility across the *whole* environment at once. Reach for `--pypi` only after checking conda-forge and coming up empty.
+
+### Packages from other channels
+
+`conda-forge` isn't the only channel, and it isn't always where a package lives. `bioconda`, for example, hosts a large share of the bioinformatics tooling that research-computing users reach for — tools like `fastqc` that conda-forge doesn't carry. Add the channel to the workspace first:
+
+```bash
+pixi workspace channel add bioconda
+```
+
+```text
+✔ Added bioconda (https://conda.anaconda.org/bioconda/)
+```
+
+```toml title="pixi.toml"
+[workspace]
+channels = ["conda-forge", "bioconda"]
+```
+
+`channels` under `[workspace]` is an ordered list, and pixi searches it in order. Adding `bioconda` here makes every package on it available to the whole workspace, not just to whatever you add next.
+
+Most of the time you don't need to say which channel a package comes from — pixi searches the whole list and picks it up. To pin one package to a specific channel regardless of ordering, use `channel::package`:
+
+```bash
+pixi add bioconda::fastqc
+```
+
+```text
+✔ Added bioconda::fastqc
+```
+
+```toml title="pixi.toml"
+[dependencies]
+fastqc = { version = ">=0.12.1,<0.13", channel = "bioconda" }
+```
+
+Notice what landed in the manifest: not a bare version string like the other entries in `[dependencies]`, but a table with a `channel` key. `channel::package` at the command line isn't just a lookup hint — pixi records the channel choice in `pixi.toml`, so a collaborator reading the manifest (or the solver resolving it later) knows `fastqc` comes from `bioconda` specifically, not wherever else it happens to be found.

--- a/docs/fundamentals/computing-development-environments/pixi.md
+++ b/docs/fundamentals/computing-development-environments/pixi.md
@@ -1,144 +1,66 @@
 # Pixi: The evolution of cross-platform package manager
 
-Pixi is a fast, modern, and reproducible package management tool that builds upon the conda ecosystem while introducing a project-centric approach to environment management. If you're familiar with conda/mamba, this guide will help you transition to Pixi and understand its unique advantages.
+Pixi is a fast, project-centric package manager that combines the conda-forge and PyPI ecosystems behind a single manifest and a single lock file, giving you the same environment on every machine without a separate activation step.
 
-??? info "For Conda users: Conda workflows and Pixi"
+!!! info "Version"
 
-    ## Why Pixi?
+    Verified against pixi 0.73.0 (July 2026). Commands and output on this page
+    were captured from a real run against that version. Older pixi releases may
+    differ; where a feature needs a minimum version, it is noted inline.
 
-    Before Pixi, conda was the go-to tool for managing Python environments and packages, especially in data science and scientific computing. So why do we need Pixi?
+## Why pixi?
 
-    ### Conda Workflow
+You inherit a project. It has an `environment.yml` or a `requirements.txt` sitting at the top level, so you do what the README says: create the environment and run the analysis. Sometimes the solve just fails — a pinned version no longer exists on the channel, or a new release broke a transitive dependency that used to resolve cleanly. Other times it's worse: the solve succeeds, the environment builds, and you get numbers that don't match the paper.
 
-    Before answering that question, let's take a look at the current conda workflow. A typical "best practice" conda workflow involves the following steps. See the [Conda/Mamba Fundamentals](./conda-mamba.md) for more details.
+This is not bad luck. It's the default outcome. Neither conda nor pip writes a lock file unless you go out of your way to produce one — `conda env export`, `pip freeze` — and most projects don't. An `environment.yml` or `requirements.txt` describes an *intent* ("something compatible with numpy>=1.20"), not a record of what was actually installed. Solve that intent again six months later, against a channel that has moved on, and you can easily land on a different set of package versions.
 
-    ![Conda Workflow](../../assets/images/conda-workflow.png)
+Named conda environments compound the problem. A `conda create -n myenv` environment is shared and long-lived: it sits outside the project, gets `conda install`ed into over months, and nobody remembers exactly what's in it anymore. Whether it's even active is invisible state that lives in your shell, not in the project directory — you can `cd` into a project and have no idea if the right environment, or any environment, is active.
 
-    #### New Environment Process
+For the rest of this page, "reproducible" means one specific thing: **same inputs plus the same environment yields the same outputs, on anyone's machine.** Everything pixi does is in service of that definition.
 
-    - Create a conda environment yaml file
-    - Create a new conda environment from the yaml file
-    - Activate the conda environment and start working with that environment
+### The conda workflow
 
-    #### Environment Update Process
+![Conda Workflow](../../assets/images/conda-workflow.png)
 
-    - Update the conda environment yaml file
-    - Update the conda environment from the yaml file
-    - Activate the conda environment and start working with that environment
+The typical "best practice" conda workflow has three separate processes, each involving the same environment file:
 
-    #### Environment Sharing Process
+- **New environment** — write a `environment.yml`, create the environment from it, then activate it before you can work.
+- **Update** — edit the `environment.yml`, update the environment from the changed file, then reactivate.
+- **Share** — hand the `environment.yml` to a collaborator and hope their solve matches yours.
 
-    - Share the conda environment yaml file with collaborators
+Every step depends on a human remembering to keep the environment and the file in sync, and none of the steps produce an exact, replayable record of what got installed. See [Conda/Mamba Fundamentals](./conda-mamba.md) for the full conda workflow.
 
-    If you're a conda user, you might have noticed that this workflow is not very efficient. It requires you to manage multiple files, and the process of creating, updating, and sharing environments can be cumbersome, and it doesn't always guarantee reproducibility.
+### conda/mamba, uv, and pixi
 
-    ### How Pixi can help
+| Concern | conda / mamba | uv | pixi |
+| --- | --- | --- | --- |
+| Environment scope | Shared, named, global | Per-project | Per-project, tied to the folder |
+| Lock file | Opt-in (`conda env export`) | Yes, by default | Yes, written automatically on every change |
+| Task running | None | None | Built in (`pixi run <task>`) |
+| Activation | `conda activate` required | Not required | Never required |
+| conda-forge packages | Yes | No | Yes |
+| PyPI packages | Via nested `pip:` | Yes | Yes, same manifest and lock |
+| Compiled/system libs (CUDA, MKL, GDAL) | Yes | Only if a wheel exists | Yes |
 
-    Pixi addresses several common pain points developers face with traditional conda workflows:
+!!! tip "When `uv` alone is enough"
 
-    - **Project-focused**: Environments are tied to projects, not global system state
-    - **Built-in lockfiles**: Automatic dependency locking for perfect reproducibility
-    - **Task management**: Cross-platform task runner built-in
-    - **Multi-environment support**: Multiple environments per project
-    - **Speed**: Pixi is implemented in Rust for fast solving
-    - **Universal compatibility**: Works with both conda and PyPI packages
+    For a pure-Python project whose dependencies all live on PyPI, `uv` is an
+    excellent choice and you do not need pixi. Pixi earns its place when your
+    stack includes compiled or non-Python dependencies — the Python interpreter
+    itself, CUDA, MKL, GDAL's C libraries — that either are not on PyPI or ship
+    there as fragile wheels.
 
-    ### Key Differences: Conda vs Pixi
+??? info "How pixi actually solves an environment"
 
-    Here's a side-by-side comparison of common tasks:
+    Pixi does not compete with `uv` so much as build on it. When pixi solves an
+    environment it resolves the **conda** packages first with the `rattler`
+    solver, then resolves the **PyPI** packages with `uv` — and crucially, it
+    resolves the PyPI half *on top of* the conda half, so the two are guaranteed
+    compatible. Both are driven by the same SAT solver, `resolvo`, and both land
+    in a single `pixi.lock`.
 
-    | Task | Conda/Mamba | Pixi |
-    |------|-------------|------|
-    | Initializing Project | N/A | `pixi init myproject` |
-    | Creating an Environment | `conda create -n myenv python=3.11` | `pixi add python=3.11` (installs in default environment) |
-    | Activating Environment | `conda activate myenv` | `pixi shell` (activate default environment) |
-    | Installing Packages | `conda install numpy` | `pixi add numpy` (installs in default environment) |
-    | Running Commands | `conda run -n myenv python script.py` | `pixi run python script.py` (runs in default environment) |
-    | Sharing Environment | `conda export --format=yaml > environment.yaml` (will export `environment.yaml`) | Share `pixi.toml` and `pixi.lock` |
-    | Multiple Environments | Separate conda envs | Multiple envs in one project |
-
-    ## Migrating from Conda to Pixi
-
-    ### From Conda Environment Files
-
-    If you have an existing `environment.yml`:
-
-    ```yaml
-    name: my-project
-    channels:
-      - conda-forge
-      - bioconda
-    dependencies:
-    - python=3.11
-    - numpy
-    - pandas
-    - pip
-    - pip:
-        - scikit-learn
-        - matplotlib
-    ```
-
-    Convert to Pixi:
-
-    ```bash
-    # Import existing environment.yml
-    pixi init --import environment.yml my-project
-    cd my-project
-    ```
-
-    This creates an equivalent `pixi.toml` automatically.
-
-    ### From requirements.txt
-
-    For Python projects with `requirements.txt`:
-
-    ```bash
-    pixi init my-python-project
-    cd my-python-project
-
-    # Add Python first
-    pixi add python=3.11
-
-    # Add PyPI dependencies from requirements.txt
-    # (You'll need to convert these manually or use a script)
-    cat requirements.txt | xargs -I {} pixi add --pypi {}
-    ```
-
-    ## Practical Exercises
-
-    ### Exercise 1: Converting from Conda
-
-    ??? example "1. Create a traditional environment.yml"
-
-        Create a `environment.yml` file for a project:
-
-        ```yaml
-        name: conda-project
-        channels:
-        - conda-forge
-        - bioconda
-        dependencies:
-        - python=3.11
-        - pandas
-        - numpy
-        - matplotlib
-        - fastqc  # from bioconda
-        - pip
-        - pip:
-            - seaborn
-        ```
-
-
-    ??? example "2. Convert to Pixi"
-
-        ```bash
-        pixi init --import environment.yml converted-project
-        cd converted-project
-        ```
-
-    **Examine the generated pixi.toml** and understand the conversion,
-    see the rest of this document for more details on the `pixi.toml` file.
----
+    That is the real difference in scope: `uv` resolves PyPI. Pixi resolves
+    conda-forge *and* PyPI, together, in one lock file.
 
 ## Installation
 
@@ -169,306 +91,3 @@ Once you have pixi installed, you can verify by running the command below
 ```bash
 pixi --version
 ```
-
-## Pixi Concepts
-
-### 1. Creating a New Project
-
-```bash
-# Create a new project directory with pixi.toml
-pixi init my-data-project
-cd my-data-project
-```
-
-This creates a project structure:
-
-```text
-my-data-project/
-├── .gitignore
-├── .gitattributes
-└── pixi.toml
-```
-
-### 2. Understanding the Manifest File
-
-The `pixi.toml` file is the heart of your project:
-
-```toml
-[workspace]
-authors = ["Your Name <your.email@example.com>"] # (1)!
-channels = ["conda-forge"]  # (2)!
-name = "my-data-project" # (3)!
-description = "A data analysis project using Pixi" # (4)!
-platforms = ["osx-arm64"] # (5)!
-version = "0.1.0" # (6)!
-
-[tasks]
-# Cross-platform tasks go here
-
-[dependencies]
-# Conda packages go here
-
-[pypi-dependencies]
-# PyPI packages go here
-```
-
-1. The `authors` field is optional but recommended for project metadata. By default, when you run `pixi init`, it will use your git config user name and email.
-2. The `channels` field allows you to specify conda channels for package resolution.
-3. The `name` field specifies the name of your project.
-4. The `description` field is optional but useful for project metadata.
-5. The `platforms` field specifies the platforms you intend to support. By default, it will use your current platform.
-6. The `version` field specifies the version of your project.
-
-### 3. Adding Dependencies
-
-Add conda packages (equivalent to `conda install`):
-
-```bash
-pixi add python=3.11
-pixi add numpy pandas matplotlib scipy
-```
-
-Add PyPI packages:
-
-```bash
-pixi add --pypi scikit-learn seaborn
-```
-
-Add packages from specific channels:
-
-   1. First we add the channel to the workspace:
-
-    ```bash
-    pixi workspace channel add bioconda
-    ```
-
-   2. Then we can add packages from that channel:
-
-    ```bash
-    pixi add bioconda::fastqc
-    ```
-
-### 4. Locking Dependencies
-
-Pixi automatically generates a `pixi.lock` file when you add packages. This file locks the exact versions of all dependencies, ensuring reproducibility. You can also manually lock the environment to update the lockfile:
-
-```bash
-pixi lock
-```
-
-### 5. Working with Your Environment
-
-Activate the environment (equivalent to `conda activate`):
-
-```bash
-pixi shell
-```
-
-Or run commands directly:
-
-```bash
-pixi run python --version
-pixi run python -c "import numpy; print(numpy.__version__)"
-```
-
-Finer-grained control over the environment and dependencies can be achieved
-by using `feature`. Feature is a way to group dependencies and tasks together. For example, you can create a `test` feature for testing dependencies:
-
-```bash
-pixi add --feature test pytest coverage # (1)!
-pixi workspace environment add test --features test # (2)!
-```
-
-1. This adds `pytest` and `coverage` to a feature called `test`. You can then run tasks or commands specific to this feature.
-2. This adds a new environment called `test` that includes the `test` feature. You can then activate this environment.
-
-To activate the `test` environment, you can use:
-
-```bash
-pixi shell -e test
-```
-
-### 6. Task Management
-
-Define cross-platform tasks in your `pixi.toml`:
-
-```toml
-[tasks]
-# Simple commands
-clean = "rm -rf __pycache__ .pytest_cache"
-pytest = "pytest tests/"
-coverage = "coverage report"
-
-# Multi-step tasks
-test = { depends-on = ["pytest", "coverage"] }
-
-# Task with required arguments
-[tasks.greet]
-args = ["name"]
-cmd = "echo Hello, {{ name }}!"
-
-# Task with optional arguments (default values)
-[tasks.build]
-args = [
-{ "arg" = "project", "default" = "my-app" },
-{ "arg" = "mode", "default" = "development" },
-]
-cmd = "echo Building {{ project }} in {{ mode }} mode"
-
-# Task with mixed required and optional arguments
-[tasks.deploy]
-args = ["service", { "arg" = "environment", "default" = "staging" }]
-cmd = "echo Deploying {{ service }} to {{ environment }}"
-
-```
-
-Run tasks:
-
-```bash
-pixi run clean
-pixi run test
-pixi run greet --name Bob
-pixi run build --project my-app --mode production
-pixi run deploy --service my-service --environment production
-```
-
-### 7. Platform-Specific Dependencies
-
-These dependencies will only be installed on the specified platform. This is useful for packages that are platform-specific, like compilers or system libraries.
-
-```toml
-# Different dependencies per platform
-[dependencies]
-python = "3.11.*"
-
-[target.linux-64.dependencies]
-# Linux-specific packages
-gcc = "*"
-
-[target.win-64.dependencies] 
-# Windows-specific packages
-vs2019_win-64 = "*"
-
-[target.osx-arm64.dependencies]
-# macOS ARM-specific packages
-```
-
-### 8. Global Tool Installation
-
-Pixi can also install global tools (like conda's base environment):
-
-```bash
-# Install global tools
-pixi global install ripgrep bat fd-find
-pixi global install jupyter --expose jupyter --expose ipython
-
-# List installed global tools
-pixi global list
-```
-
-## Practical Exercises
-
-### Exercise 1: Create Your First Pixi Project
-
-??? example "1. Create a new project"
-
-    ```bash
-    pixi init my-analysis
-    cd my-analysis
-    ```
-
-??? example "2. Add dependencies"
-
-    ```bash
-    pixi add python=3.11 pandas numpy matplotlib
-    pixi add --pypi seaborn
-    ```
-
-??? example "3. Create a simple analysis script"
-
-    ```python
-    # analysis.py
-    import pandas as pd
-    import numpy as np
-    import matplotlib.pyplot as plt
-    import seaborn as sns
-    
-    # Create sample data
-    data = pd.DataFrame({
-        'x': np.random.randn(100),
-        'y': np.random.randn(100)
-    })
-    
-    # Create plot
-    plt.figure(figsize=(8, 6))
-    sns.scatterplot(data=data, x='x', y='y')
-    plt.title('Sample Analysis')
-    plt.savefig('analysis.png')
-    print("Analysis complete! Check analysis.png")
-    ```
-
-??? example "4. Add task called `analyze` for running script"
-
-    ```bash
-    pixi task add analyze "python analysis.py"
-    ```
-
-??? example "5. Run the `analyze` task:"
-
-    ```bash
-    pixi run analyze
-    ```
-
-**Examine the output** in the CLI. What does it show?
-
-### Exercise 2: Create Multi-Environment Setup
-
-??? example "1. Add testing dependencies to a feature"
-
-    ```bash
-    pixi add --feature test pytest
-    ```
-
-??? example "2. Update your pixi.toml to define environments"
-
-    ```toml
-    [environments]
-    default = {solve-group = "default"}
-    test = {features = ["test"], solve-group = "default"}
-    ```
-
-??? example "3. Create a test file"
-
-    ```python
-    # test_analysis.py
-    import pandas as pd
-    import numpy as np
-    
-    def test_data_creation():
-        data = pd.DataFrame({
-        'x': np.random.randn(10),
-        'y': np.random.randn(10)
-        })
-        assert len(data) == 10
-        assert 'x' in data.columns
-        assert 'y' in data.columns
-    ```
-
-??? example "4. Add test task and run it"
-
-    ```bash
-    pixi task add test "pytest test_analysis.py -v"
-    pixi run -e test test
-    ```
-
-**Congratulations!** If you've completed these exercises, you now have a solid understanding of Pixi's core concepts and how to use it effectively in your projects.
-
-## Resources and Further Reading
-
-To be a Pixi expert, explore their [**Official Documentation**](https://pixi.sh/latest/).
-
-## Conclusion
-
-Pixi represents the evolution of conda-based package management, bringing modern development practices like project-centric environments, automatic lockfiles, and integrated task management. For conda users, the transition involves shifting from global environment-centric to project-centric thinking, but the benefits in reproducibility, collaboration, and development velocity hopefully make it worthwhile.
-
-Start with simple projects, gradually adopt advanced features like multi-environment setups and task management, and you'll find Pixi to be a powerful upgrade to your development workflow.


### PR DESCRIPTION
Rewrites the Pixi page as a complete fundamentals guide, verified end to end against **pixi 0.73.0**. 474 → 921 lines, one file changed.

## Why

The existing page had a broken command, several claims that no longer matched current pixi, and taught environments and tasks only as hand-written TOML. It also buried the entire conda rationale — the reason most readers open the page — inside a collapsed block, and said nothing about `uv`, which is now the most common question people arrive with.

## What changed

The page follows one arc, with a seeded Monte Carlo π script threading through it so every output block is reproducible:

why pixi (vs conda **and** uv) → install → first project → the `pixi.toml` / `pixi.lock` / `.pixi` model → running code → tasks → the lock file → features and environments → PyPI and channels → inspection → `pixi global` → conda migration → cheat sheet → going further → appendices.

Each concept is taught as a CLI command followed by the manifest TOML it produces, with a consolidated CLI ↔ manifest cheat sheet for lookup.

### Bugs fixed

- **`pixi workspace environment add --features` → `--feature`.** The old flag is wrong; the command fails as previously documented.
- **Task arguments were documented with flag-style invocation** (`pixi run greet --name Bob`), which errors on 0.73.0 — arguments are positional. The `build` example also failed independently because pixi's task shell treats a bare `in` as a reserved word.
- **`pixi add --pypi scikit-learn seaborn`** was the PyPI example. Both are on conda-forge, so it modelled the wrong instinct.
- **`cat requirements.txt | xargs -I {} pixi add --pypi {}`** ran one full solve per line. Replaced with a batched call; `xargs` is retained in prose as a named anti-pattern.
- **The manifest walkthrough annotated six `[workspace]` fields as generated.** pixi 0.73.0 writes only four — `authors` and `description` are yours to add.

### New coverage

`uv` comparison and how pixi's solve actually works (`rattler` for conda, `uv` for PyPI, both over `resolvo`, one lock) · what `pixi.lock` actually contains · restoring an environment from the lock · the conda-vs-PyPI preference rule and how to check with `pixi search` · `pixi list` / `tree` / `info` / `task list` · multi-platform-aware framing of `platforms`.

Deferred to a future advanced guide, with links to official docs: `pyproject.toml` for maintainers, multi-platform locking, CI with `setup-pixi`, solve groups. Nothing accurate was deleted — `[target.*]` platform dependencies and task-argument templating survive as collapsed appendices.

## Verification

Every command was run against pixi 0.73.0 on `osx-arm64` and its real output transcribed; nothing is invented. Volatile values are elided where they are incidental, kept where they are the lesson.

Reviews caught four defects that reading alone would have missed — the task-argument syntax, a `pixi global list` block attached to the `install` command, a `grep -A 6` that returns 7 lines against a 9-line shown block, and a package count measured against the wrong project state. All were re-measured and corrected.

## Reviewer notes

- **The page is now the longest in the repo** (921 lines, against 100–260 for its siblings). That is the cost of "extensive"; section headings and the cheat sheet carry scannability. Worth a second opinion on whether the split point to the advanced guide is in the right place.
- **`humanize` is used as the `--pypi` example but is itself on conda-forge.** This is deliberate and stated: rather than assert any package is PyPI-only — a claim that rots, and that name normalisation makes easy to get wrong (`great-tables` ships as `great_tables`) — the section teaches readers to check with `pixi search`.
- The `mkdocs build` warning naming `docker.md` is pre-existing and unrelated.
- No `mkdocs.yml` or `.nav.yml` change; the file keeps its path, so navigation is unaffected.
