### PR TITLE
chore: ignore local .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Claude files
+/.claude/
+
 # Distribution / packaging
 .Python
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ __pycache__/
 *.so
 
 # Claude files
-/.claude/
+.claude/
 
 # Distribution / packaging
 .Python


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore`. Claude Code writes per-developer config and custom commands there, which is local tooling state rather than project content.
- Without this, `.claude/` shows up as untracked in everyone's `git status`, and is easy to commit by accident with a broad `git add`.

## Changes

- `.gitignore`: new `# Claude files` entry for `.claude/`, placed alongside the other tooling ignores.

The pattern is unanchored, matching the other tooling entries in the file (`__pycache__/`, `.pytest_cache/`, `.pixi`), so it ignores a `.claude/` directory at any depth. An earlier revision anchored it to the repository root; per review that was guarding a case that does not exist, and it has been dropped.

## Test plan

- [x] Nothing under `.claude/` is currently tracked (`git ls-files` finds no `.claude` path anywhere in the repo), so the rule takes effect rather than being a no-op on already-tracked files
- [x] `git check-ignore -v` matches both `.claude/` at the root and a nested `docs/.claude/`
- [x] `git status` is clean with the local `.claude/commands` directory present
- [x] Diff is three added lines in one file, no other paths touched
